### PR TITLE
Add python 3 tkinter import

### DIFF
--- a/prog-o-meter.py
+++ b/prog-o-meter.py
@@ -14,7 +14,10 @@ __version__ = "1.0.0"
 __license__ = "MIT"
 
 
-import Tkinter as Tk
+try:
+    import Tkinter as Tk        # Python < 3.0
+except ImportError:
+    import tkinter as Tk        # Python >= 3.0
 
 class ProgressGUI(object):
     


### PR DESCRIPTION
Checks if Tkinter can be imported in the python 2 way.
If that fails, it tries to import tkinter the python 3 way.
It's a first step toward resolving issue #45 